### PR TITLE
add example Mistral AI "La plateforme" configuration (using OpenAI provider)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,49 @@ OpenAI prompts can take an additional option field to talk to compatible API's.
 - `endpoint?: string` - (Optional) Endpoint to use in the request URL. Defaults to 'chat/completions'.
 - `authorization?: string` - (Optional) Authorization header to include in the request. Overrides any authorization given through the environment key.
 
+For example, to configure it for Mistral AI "La plateforme":
+
+```lua
+  {
+      "gsuuon/model.nvim",
+      cmd = { "Model", "Mchat" },
+      init = function()
+          vim.filetype.add({ extension = { mchat = "mchat" } })
+      end,
+      ft = "mchat",
+      keys = { { "<leader>h", ":Model<cr>", mode = "v" } },
+      config = function()
+          local mistral = require("model.providers.openai")
+          local util = require("model.util")
+          require("model").setup({
+              hl_group = "Substitute",
+              prompts = util.module.autoload("prompt_library"),
+              default_prompt = {
+                  provider = mistral,
+                  options = {
+                      url = "https://api.mistral.ai/v1/",
+                      authorization = "Bearer YOUR_MISTRAL_API_KEY",
+                  },
+                  builder = function(input)
+                      return {
+                          model = "mistral-medium",
+                          temperature = 0.3,
+                          max_tokens = 400,
+                          messages = {
+                              {
+                                  role = "system",
+                                  content = "You are helpful assistant.",
+                              },
+                              { role = "user", content = input },
+                          },
+                      }
+                  end,
+              },
+          })
+      end,
+  },
+```
+
 </details>
 
 ### LlamaCpp


### PR DESCRIPTION
Add an example config for Mistral API