### PR TITLE
add langserve provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ The available providers are in [./lua/model/providers](./lua/model/providers).
 - [together](#together)
 - [huggingface](#huggingface-api)
 - [kobold](#kobold)
+- [langserve](#langserve)
 - [your own](#adding-your-own)
 
 ### OpenAI ChatGPT
@@ -509,6 +510,26 @@ Set the model field on the params returned by the builder (or the static params 
 
 ### Kobold
 For older models that don't work with llama.cpp, koboldcpp might still support them. Check their [repo](https://github.com/LostRuins/koboldcpp/) for setup info.
+
+### Langserve
+
+Set the `output_parser` to correctly parse the contents returned from the `/stream` endpoint and use the `builder` to construct the input query. The below uses the [example langserve application](https://github.com/langchain-ai/langserve-launch-example) to make a joke about the input text.
+
+```lua
+  ['langserve:make-a-joke'] = {
+    provider = langserve,
+    options = {
+      base_url = 'https://langserve-launch-example-vz4y4ooboq-uc.a.run.app/',
+      output_parser = langserve.generation_chunk_parser,
+    },
+    builder = function(input, context)
+      return {
+        topic = input,
+      }
+    end
+  },
+```
+
 
 ### Adding your own
 [Providers](#provider) implement a simple interface so it's easy to add your own. Just set your provider as the `provider` field in a prompt. Your provider needs to kick off the request and call the handlers as data streams in, finishes, or errors. Check [the hf provider](./lua/model/providers/huggingface.lua) for a simpler example supporting server-sent events streaming. If you don't need streaming, just make a request and call `handler.on_finish` with the result.

--- a/lua/model/providers/langserve.lua
+++ b/lua/model/providers/langserve.lua
@@ -1,0 +1,109 @@
+local curl = require('model.util.curl')
+local util = require('model.util')
+local provider_util = require('model.providers.util')
+
+local M = {}
+
+local function parse_llmchain_data(item)
+  local data = util.json.decode(item)
+
+  if data ~= nil and data["text"] ~= nil then
+    return {
+      content = data["text"]
+    }
+  end
+end
+
+---@param handlers StreamHandlers
+---@param params? any Additional options for OpenAI endpoint
+---@param options? { output_parser: FunctionItem, base_url?: string } Request endpoint and url. Defaults to 'https://api.openai.com/v1/' and 'chat/completions'. `authorization` overrides the request auth header. If url is provided the environment key will not be sent, you'll need to provide an authorization.
+function M.request_completion(handlers, params, options)
+  local _all_content = ''
+  options = options or {}
+
+  local endpoint = 'stream'
+
+  local extract_data = options.output_parser
+
+  -- TODO should handlers being optional be a choice at the provider level or always optional for all providers?
+  local _handlers = vim.tbl_extend("force", {
+    on_partial = util.noop,
+    on_finish = util.noop,
+    on_error = util.noop,
+  }, handlers)
+
+  local handle_raw = provider_util.iter_sse_messages(function(message)
+    if message.event == "metadata" then
+      return
+    end
+
+    if message.event == "end" then
+      _handlers.on_finish(_all_content)
+      return
+    end
+
+    local data = extract_data(message.data)
+
+    if data ~= nil then
+      if data.content ~= nil then
+        _all_content = _all_content .. data.content
+        _handlers.on_partial(data.content)
+      end
+
+    else
+      local response = util.json.decode(message)
+
+      if response ~= nil then
+        _handlers.on_error(response, 'response')
+      else
+        -- TODO?
+        -- if not message:match('%[DONE%]') then
+        --   _handlers.on_error(message, 'message')
+        -- end
+      end
+    end
+  end)
+
+  local function handle_error(error)
+    _handlers.on_error(error, 'curl')
+  end
+
+  -- local body = vim.tbl_deep_extend('force', default_params, params)
+  local body = {
+      input = params,
+  }
+
+  local headers = { ['Content-Type'] = 'application/json' }
+
+  local url_ = options.base_url
+  if url_ then
+    -- ensure we have a trailing slash if url was provided by options
+    if not url_:sub(-1) == '/' then
+      url_ = url_ .. '/'
+    end
+  else
+    -- default to local langserve
+    url_ = 'http://127.0.0.1:8000/'
+  end
+
+  return curl.stream({
+    headers = headers,
+    method = 'POST',
+    url = url_ .. endpoint,
+    body = body,
+  }, handle_raw, handle_error)
+end
+
+--- Sets default openai provider params. Currently enforces `stream = true`.
+function M.initialize(opts)
+  default_params = vim.tbl_deep_extend('force',
+    default_params,
+    opts or {},
+    {
+      stream = true -- force streaming since data parsing will break otherwise
+    })
+end
+
+M.llmchain_output_parser = parse_llmchain_data
+
+return M

--- a/lua/model/providers/langserve.lua
+++ b/lua/model/providers/langserve.lua
@@ -82,7 +82,7 @@ function M.request_completion(handlers, params, options)
   local url_ = options.base_url
   if url_ then
     -- ensure we have a trailing slash if url was provided by options
-    if not url_:sub(-1) == '/' then
+    if not (url_:sub(-1) == '/') then
       url_ = url_ .. '/'
     end
   else

--- a/lua/model/providers/openai.lua
+++ b/lua/model/providers/openai.lua
@@ -100,7 +100,7 @@ function M.request_completion(handlers, params, options)
   local url_ = options.url
   if url_ then
     -- ensure we have a trailing slash if url was provided by options
-    if not url_:sub(-1) == '/' then
+    if not (url_:sub(-1) == '/') then
       url_ = url_ .. '/'
     end
   else

--- a/lua/model/providers/util.lua
+++ b/lua/model/providers/util.lua
@@ -42,6 +42,7 @@ function M.iter_sse_messages(fn)
   local pending_output = ''
 
   return function(raw)
+    raw = raw:gsub('\r', '') -- handle some providers using \r
     pending_output = pending_output .. '\n' .. raw
 
     pending_output = pending_output:gsub('(.-)\n\n', function(message)


### PR DESCRIPTION
Adds a provider for remote, runnable LLM chains deployed with [Langserve](https://github.com/langchain-ai/langserve). Exports two output parsers, `generation_chunk_parser` and `chat_generation_chunk_parser`, for two common output schemas for langserve `/stream` endpoints.