### PR TITLE
fix: carriage return in response

### DIFF
--- a/lua/model/util/curl.lua
+++ b/lua/model/util/curl.lua
@@ -65,6 +65,9 @@ local function run_curl(opts, stream, on_stdout, on_error, on_exit, on_headers)
 
     on_curl_out = function(out)
       if got_headers then
+        if out ~= nil then
+          out = out:gsub('\r', '')
+        end
         on_stdout(out)
       else
         buffered = buffered .. out:gsub('\r', '')


### PR DESCRIPTION
When using an openai compatible API (text-generation-webui) I kept getting no response in nvim, while it was being generated and received on the network. Upon inspecting the response I saw that all but the first message had `\r\n\r\n` at their ends. Looking at the code it seems that the carriage return gets removed for the first message with the headers, but not for subsequent messages. I think there's more to this, but I'm very new to Lua, so digging deeper is proving difficult. 