### PR TITLE
fix: notify when in lua loop callback

### DIFF
--- a/lua/model/core/chat.lua
+++ b/lua/model/core/chat.lua
@@ -296,11 +296,11 @@ function M.run_chat(opts)
       seg.clear_hl()
 
       if reason and reason ~= 'stop' and reason ~= 'done' then
-        vim.notify(reason)
+        util.notify(reason)
       end
     end,
     on_error = function(err, label)
-      vim.notify(vim.inspect(err), vim.log.levels.ERROR, { title = label })
+      util.notify(vim.inspect(err), vim.log.levels.ERROR, { title = label })
       seg.set_text('')
       seg.clear_hl()
     end,

--- a/lua/model/util/init.lua
+++ b/lua/model/util/init.lua
@@ -4,6 +4,14 @@ local M = {}
 
 function M.noop() end
 
+function M.notify(msg, level, opts)
+  if vim.in_fast_event() then
+    vim.schedule(function() vim.notify(msg, level, opts) end)
+  else
+    vim.notify(msg, level, opts)
+  end
+end
+
 local function show(item, level, opt)
   local _body = type(item) == 'string' and item or vim.inspect(item)
   local _level = level or vim.log.levels.INFO
@@ -13,7 +21,7 @@ local function show(item, level, opt)
     type(opt) == 'string' and { title = opt } or
     opt
 
-  vim.notify(_body, _level, _opt)
+  M.notify(_body, _level, _opt)
 end
 
 function M.show(item, opt)
@@ -448,7 +456,7 @@ function M.buf.prompt(callback, initial_content, title)
     local success, result = pcall(callback, user_input, buf_content)
 
     if not success then
-      vim.notify(result, vim.log.levels.ERROR)
+      M.notify(result, vim.log.levels.ERROR)
     end
 
     vim.cmd(':bd! ' .. bufnr)


### PR DESCRIPTION
I frequently got following error from request handlers or `util.show` / `util.eshow` :

```
Press ENTER or type command to continue
Error executing luv callback:
vim/_editor.lua:0: E5560: nvim_echo must not be called in a lua loop callback
stack traceback:
        [C]: in function 'nvim_echo'
        vim/_editor.lua: in function 'notify'
        ...local/share/nvim/lazy/model.nvim/lua/model/util/init.lua:16: in function 'show'
        ...local/share/nvim/lazy/model.nvim/lua/model/util/init.lua:20: in function 'show'
```

It looks that when using the provided `async(function(wait, resolve)` helper one needs to schedule displaying the notification instead of notifying directly in the callback.