### PR TITLE
Treesitter mchat

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ https://github.com/gsuuon/model.nvim/assets/6422188/3af3e65d-d13c-4196-abe1-07d6
 - 🦜 Chat in `mchat` filetype buffer
   - edit settings or messages at any point
   - take conversations to different models
-  - basic syntax highlights and folds
+  - treesitter highlights and folds
 
 ### Contents
 - [Setup](#setup)
@@ -89,6 +89,11 @@ require('lazy').setup({
   }
 })
 ```
+
+### Treesitter
+To get treesitter highlighting of [chat buffers](#chat-prompts) with markdown injections, use `:TSInstall mchat` after model.nvim has been loaded (if you're using Lazy run `:Lazy load model.nvim` first). The grammar repo is at [gsuuon/tree-sitter-mchat](https://github.com/gsuuon/tree-sitter-mchat/).
+
+![image](https://github.com/gsuuon/model.nvim/assets/6422188/6f7d9d9c-f3a7-4671-b7a4-307f727108a3)
 
 ## Usage
 

--- a/lua/model/init.lua
+++ b/lua/model/init.lua
@@ -417,9 +417,7 @@ function M.setup(opts)
 
   setup_commands()
 
-  if not pcall(setup_treesitter_info) then
-    util.eshow('[model.nvim] Failed to setup treesitter info')
-  end
+  pcall(setup_treesitter_info)
 
   vim.g.did_setup_model = true
 end

--- a/lua/model/init.lua
+++ b/lua/model/init.lua
@@ -375,6 +375,19 @@ local function setup_commands()
   end, {})
 end
 
+local function setup_treesitter_info()
+  local parser_config = require('nvim-treesitter.parsers').get_parser_configs()
+  parser_config.mchat = {
+    install_info = {
+      url = 'https://github.com/gsuuon/tree-sitter-mchat.git',
+      files = { 'src/parser.c' },
+      branch = 'main',
+      generate_requires_npm = false,
+      requires_generate_from_grammar = false,
+    },
+  }
+end
+
 ---@class SetupOptions
 ---@field default_prompt? Prompt default = openai. The default prompt (`:M` or `:Model` with no argument)
 ---@field prompts? table<string, Prompt> default = starters. Add prompts (`:M [name]`)
@@ -403,6 +416,10 @@ function M.setup(opts)
   end
 
   setup_commands()
+
+  if not pcall(setup_treesitter_info) then
+    util.eshow('[model.nvim] Failed to setup treesitter info')
+  end
 
   vim.g.did_setup_model = true
 end

--- a/queries/mchat/folds.scm
+++ b/queries/mchat/folds.scm
@@ -1,0 +1,2 @@
+(params_block) @fold
+(assistant_message) @fold

--- a/queries/mchat/highlights.scm
+++ b/queries/mchat/highlights.scm
@@ -1,0 +1,2 @@
+(chat_handler) @type
+(system_instruction) @attribute

--- a/queries/mchat/injections.scm
+++ b/queries/mchat/injections.scm
@@ -1,0 +1,8 @@
+((params_block) @injection.content
+  (#set! injection.language "lua"))
+
+((user_message) @injection.content
+  (#set! injection.language "markdown"))
+
+((assistant_message) @injection.content
+  (#set! injection.language "markdown"))

--- a/syntax/mchat.vim
+++ b/syntax/mchat.vim
@@ -6,7 +6,15 @@ syn include @Lua syntax/lua.vim
 
 let b:current_syntax = 1
 
-setlocal foldmethod=syntax
+lua << EOF
+local ok, parsers = pcall(require, "nvim-treesitter.parsers")
+if ok then
+  if not parsers.has_parser() then
+    vim.opt_local.foldmethod = 'syntax'
+  end
+end
+EOF
+
 syn sync fromstart
 
 syn match modelChatName /\%^\(---\)\@!.\+/ skipnl nextgroup=modelChatMessageSystem,modelChatParams,modelChatMessages


### PR DESCRIPTION
Adds tree-sitter support (from https://github.com/gsuuon/tree-sitter-mchat) with markdown injections - install with `:TSInstall mchat` (make sure model.nvim has been loaded if lazy loading)

![image](https://github.com/gsuuon/model.nvim/assets/6422188/6f7d9d9c-f3a7-4671-b7a4-307f727108a3)

resolves #44 