### PR TITLE
stop adding separator when completing a partial assistant response

### DIFF
--- a/lua/model/core/chat.lua
+++ b/lua/model/core/chat.lua
@@ -254,10 +254,17 @@ function M.run_chat(opts)
     error('Chat prompt run() returned nil')
   end
 
-  local seg = segment.create_segment_at(#buf_lines, 0)
-
   local starter_seperator = needs_nl(buf_lines) and '\n======\n' or '======\n'
-  seg.add(starter_seperator)
+  local seg
+
+  local last_msg = parsed.contents.messages[#parsed.contents.messages]
+
+  if last_msg.role == 'user' then
+    seg = segment.create_segment_at(#buf_lines, 0)
+    seg.add(starter_seperator)
+  else
+    seg = segment.create_segment_at(#buf_lines-1, #buf_lines[#buf_lines])
+  end
 
   local sayer = juice.sayer()
 

--- a/lua/model/core/chat.lua
+++ b/lua/model/core/chat.lua
@@ -254,14 +254,14 @@ function M.run_chat(opts)
     error('Chat prompt run() returned nil')
   end
 
-  local starter_seperator = needs_nl(buf_lines) and '\n======\n' or '======\n'
+  local starter_separator = needs_nl(buf_lines) and '\n======\n' or '======\n'
   local seg
 
   local last_msg = parsed.contents.messages[#parsed.contents.messages]
 
   if last_msg.role == 'user' then
     seg = segment.create_segment_at(#buf_lines, 0)
-    seg.add(starter_seperator)
+    seg.add(starter_separator)
   else
     seg = segment.create_segment_at(#buf_lines-1, #buf_lines[#buf_lines])
   end
@@ -278,7 +278,7 @@ function M.run_chat(opts)
       sayer.finish()
 
       if text then
-        seg.set_text(starter_seperator .. text .. '\n======\n')
+        seg.set_text((last_msg.role == 'user' and (starter_separator .. text) or text) .. '\n======\n')
       else
         seg.add('\n======\n')
       end


### PR DESCRIPTION
Hello, thank you for a great plugin!

Sometimes it is convenient to prepare the "assistant" response before sending the whole prompt to an LLM. E.g. I can type manually:
```
> You are a helpful assistant.
Hello!

======
Hello! What a
```
and run `:Mchat` here. I would expect the LLM to continue `Hello! What a` with `nice day!` for example.

In chat mode, this can be done by creating a prompt like that:
```lua
run = function(messages,config)
  local prompt = '<|start_header_id|>system<|end_header_id|>\n' .. config.system
  for _, msg in ipairs(messages) do
    prompt = prompt
    .. '<|eot_id|>\n\n<|start_header_id|>'
    .. (msg.role == 'user' and 'user' or 'assistant')
    .. '<|end_header_id|>\n'
    .. msg.content
  end
  --- allow editing ai response
  if messages[#messages].role == 'user' then
    prompt = prompt .. '<|eot_id|>\n\n<|start_header_id|>assistant<|end_header_id|>\n'
  end

  return { prompt = prompt }
end,
```

However, doing as described above will make the assistant response be written after a separator as if it is a new message:

```
> You are a helpful assistant.
Hello!

======
Hello! What a
======
 lovely day it is. How can I assist you today?
```
`Hello! What a` is what I typed, and ` lovely day...` is the llm's "assistant" response.

This PR adds a simple change to chat processing s.t. a separator is not added when the last message belongs to the assistant. I.e. if the last message belongs to the assistant, then new messages from LLM should be concatenated with it.