### PR TITLE
Adding a Groq provider.

### DIFF
--- a/lua/model/format/groq_cloud.lua
+++ b/lua/model/format/groq_cloud.lua
@@ -1,0 +1,22 @@
+return {
+  ---@param messages ChatMessage[]
+  ---@param config ChatConfig
+  chat = function(messages, config)
+    -- if there's a system message, append it to the beginning
+    if config.system then
+      return {
+        messages = {
+          {
+            content = config.system,
+            role = 'system',
+          },
+          unpack(messages),
+        },
+      }
+    else
+      return {
+        messages = messages,
+      }
+    end
+  end,
+}

--- a/lua/model/providers/groq_cloud.lua
+++ b/lua/model/providers/groq_cloud.lua
@@ -1,0 +1,34 @@
+local util = require('model.util')
+local curl = require('model.util.curl')
+
+local M = {}
+
+function M.request_completion(handlers, params, options)
+  -- vim.notify(vim.inspect({ handlers = handlers }))
+  -- vim.notify(vim.inspect({ params = params, options = options }))
+
+  request_body = vim.tbl_deep_extend('force', params, options)
+  -- vim.notify(vim.inspect({ request_body = request_body }))
+
+  return curl.request({
+    url = 'https://api.groq.com/openai/v1/chat/completions',
+    method = 'POST',
+    headers = {
+      Authorization = 'Bearer ' .. util.env('GROQ_API_KEY'),
+      ['Content-Type'] = 'application/json',
+    },
+    body = request_body,
+  }, function(response)
+    local data = util.json.decode(response)
+    -- vim.notify(vim.inspect({ data = data }))
+    if data == nil then
+      handlers.on_error('Failed to decode Groq API response: ' .. response)
+      error('Failed to decode Groq API response: ' .. response)
+    end
+    -- TODO : use other returned stats as well?
+    assistant_message = data.choices[1].message.content
+    handlers.on_finish(assistant_message, 'stop')
+  end, handlers.on_error)
+end
+
+return M


### PR DESCRIPTION
This PR adds a Groq Cloud API provider to the defaults. Groq's API is already pretty fast, so we probably don't need streaming (atleast for text modalities). The chat example is also minimal (and can be replicated for other models/modalities, it's pretty simple)!