### PR TITLE
Deepseek reasoning

### DIFF
--- a/lua/model/core/chat.lua
+++ b/lua/model/core/chat.lua
@@ -300,6 +300,8 @@ function M.run_chat(opts)
     seg = segment.create_segment_at(#buf_lines - 1, #buf_lines[#buf_lines])
   end
 
+  seg.clear_hl()
+
   local sayer = juice.sayer()
 
   ---@type StreamHandlers

--- a/lua/model/format/starling.lua
+++ b/lua/model/format/starling.lua
@@ -6,12 +6,12 @@ return {
       error('Need at least one message')
     end
 
-    local first_msg = messages[1] 
+    local first_msg = messages[1]
     local prompt = 'GPT4 Correct User: '
       .. (config.system and config.system .. '\n' or '')
       .. first_msg.content
       .. '<|end_of_turn|>'
-    
+
     for i, msg in ipairs(messages) do
       if i > 1 then
         prompt = prompt

--- a/lua/model/providers/deepseek.lua
+++ b/lua/model/providers/deepseek.lua
@@ -1,0 +1,138 @@
+local util = require('model.util')
+local sse = require('model.util.sse')
+
+local function extract(data)
+  if data == nil or data.choices == nil or data.choices[1] == nil then
+    return
+  end
+
+  return {
+    content = data.choices[1].delta.content,
+    reasoning_content = data.choices[1].delta.reasoning_content,
+    finish_reason = data.choices[1].finish_reason,
+  }
+end
+
+local reasoning_delimit_start = '<<<<<< reasoning\n'
+local reasoning_delimit_stop = '\n>>>>>>\n'
+
+local function strip_reasoning(text)
+  -- Find the start and end positions of the reasoning block
+  local start_pos, end_pos =
+    text:find(reasoning_delimit_start .. '.-' .. reasoning_delimit_stop)
+
+  -- If the reasoning block is found, remove it from the text
+  if start_pos and end_pos then
+    return text:sub(1, start_pos - 1) .. text:sub(end_pos + 1)
+  end
+
+  -- If no reasoning block is found, return the original text
+  return text
+end
+
+---@param handler StreamHandlers
+local function reason_in_code_block(handler)
+  local is_reasoning = false
+
+  return {
+    reason = function(partial)
+      if is_reasoning then
+        handler.on_partial(partial)
+      else
+        is_reasoning = true
+        handler.on_partial(reasoning_delimit_start .. partial)
+      end
+    end,
+    content = function(partial)
+      if is_reasoning then
+        is_reasoning = false
+        handler.on_partial(reasoning_delimit_stop .. partial)
+      else
+        handler.on_partial(partial)
+      end
+    end,
+    finish = handler.on_finish,
+  }
+end
+
+---@param handler StreamHandlers
+local function reason_hidden(handler)
+  local is_reasoning = false
+
+  return {
+    reason = function()
+      if not is_reasoning then
+        is_reasoning = true
+        util.show('Reasoning..')
+      end
+    end,
+    content = handler.on_partial,
+    finish = handler.on_finish,
+  }
+end
+
+--- Deepseek provider
+--- options:
+--- {
+---   show_reasoning: boolean
+---   url: string
+---   authorization: string
+---   beta: boolean
+--- }
+---@class Provider
+local M = {
+  request_completion = function(handler, params, options)
+    local handle = options.show_reasoning and reason_in_code_block(handler)
+      or reason_hidden(handler)
+
+    local url = options.url
+      or (
+        options.beta and 'https://api.deepseek.com/beta/chat/completions'
+        or 'https://api.deepseek.com/chat/completions'
+      )
+
+    return sse.curl_client({
+      url = url,
+      method = 'POST',
+      headers = vim.tbl_extend('force', {
+        ['Content-Type'] = 'application/json',
+        ['Authorization'] = options.authorization
+          or ('Bearer ' .. util.env('DEEPSEEK_API_KEY')),
+      }, options.headers or {}),
+      body = vim.tbl_deep_extend('force', params, { stream = true }),
+    }, {
+      on_message = function(msg)
+        local data = util.json.decode(msg.data)
+
+        local chunk = extract(data)
+
+        if chunk ~= nil then
+          if chunk.reasoning_content ~= nil then
+            handle.reason(chunk.reasoning_content)
+          elseif chunk.finish_reason ~= nil then
+            handle.finish(nil, chunk.finish_reason)
+          elseif chunk.content ~= nil then
+            handle.content(chunk.content)
+          end
+        end
+      end,
+      on_error = handler.on_error,
+      on_other = handler.on_error,
+    })
+  end,
+  strip_asst_messages_of_reasoning = function(body)
+    return vim.tbl_deep_extend('force', body, {
+      messages = vim.tbl_map(function(msg)
+        if msg.role == 'assistant' then
+          return vim.tbl_deep_extend('force', msg, {
+            content = strip_reasoning(msg.content),
+          })
+        else
+          return msg
+        end
+      end, body.messages),
+    })
+  end,
+}
+
+return M

--- a/lua/model/util/segment.lua
+++ b/lua/model/util/segment.lua
@@ -203,6 +203,7 @@ local function create_segment_at(row, col, bufnr, hl_group, join_undo)
     clear_hl = vim.schedule_wrap(function()
       local mark = get_details()
 
+      _hl_group = nil
       mark.details.hl_group = nil
       mark.details.id = _ext_id
 

--- a/lua/model/util/sse.lua
+++ b/lua/model/util/sse.lua
@@ -29,8 +29,8 @@ end
 ---Handles Server-Sent Event messages as well as non-SSE responses
 ---@class SseHandler
 ---@field on_message fun(msg: {data:string, [string]:string }, pending: string): nil
----@field on_other fun(out: string): nil
----@field on_error fun(out: string): nil
+---@field on_other fun(out: string): nil any pending messages on exit (may be errors)
+---@field on_error fun(out: string): nil streaming error (curl errors)
 ---@field on_exit? fun(): nil
 
 ---Exposes handlers for curl output and translates for use with SSE handlers

--- a/lua/tests/prompts_spec.lua
+++ b/lua/tests/prompts_spec.lua
@@ -31,6 +31,10 @@ describe('prompt', function()
         after = 'table',
         args = 'string',
         filename = 'string',
+        position = {
+          col = 'number',
+          row = 'number',
+        },
         selection = {
           start = {
             col = 'number',

--- a/queries/mchat/folds.scm
+++ b/queries/mchat/folds.scm
@@ -1,2 +1,3 @@
 (params_block) @fold
+(assistant_message (reasoning) @fold)
 (assistant_message) @fold

--- a/queries/mchat/highlights.scm
+++ b/queries/mchat/highlights.scm
@@ -1,2 +1,3 @@
 (chat_handler) @type
 (system_instruction) @attribute
+(reason_delimiter) @punctuation.delimiter

--- a/queries/mchat/highlights.scm
+++ b/queries/mchat/highlights.scm
@@ -1,3 +1,4 @@
 (chat_handler) @type
 (system_instruction) @attribute
 (reason_delimiter) @punctuation.delimiter
+(turn_delimiter) @punctuation.delimiter

--- a/queries/mchat/injections.scm
+++ b/queries/mchat/injections.scm
@@ -4,5 +4,9 @@
 ((user_message) @injection.content
   (#set! injection.language "markdown"))
 
-((assistant_message) @injection.content
+((assistant_message
+   (content) @injection.content)
+  (#set! injection.language "markdown"))
+
+((reasoning) @injection.content
   (#set! injection.language "markdown"))


### PR DESCRIPTION
Adds a Deepseek provider that shows reasoning for chat conversations.

The 'deepseek:reasoner' chat prompt shows the reasoning stream from assistant responses and strips reasoning text from inputs.

The treesitter grammar has been updated with a reasoning node so the reasoning output can be folded away. You'll see errors about invalid nodes in queries unless you update the treesitter mchat parser. You can update using Lazy by restarting Neovim, then `:Lazy load model.nvim` and then `:TSInstall mchat`.

[model-reasoning.webm](https://github.com/user-attachments/assets/92e1e9a9-0c62-480f-a049-204a973e3afa)
