### PR TITLE
[mchat] don't overwrite config.system with nil first line

### DIFF
--- a/lua/model/core/chat.lua
+++ b/lua/model/core/chat.lua
@@ -146,7 +146,9 @@ end
 function M.parse(text)
   local parsed = parse_config(text)
   local messages_and_system = split_messages(parsed.rest)
-  parsed.config.system = messages_and_system.system
+  if messages_and_system.system ~= nil then
+    parsed.config.system = messages_and_system.system
+  end
 
   return {
     contents = {

--- a/lua/model/providers/perplexity.lua
+++ b/lua/model/providers/perplexity.lua
@@ -176,7 +176,7 @@ function M.strip_asst_messages_of_citations(body)
     messages = vim.tbl_map(function(msg)
       if msg.role == 'assistant' then
         return vim.tbl_deep_extend('force', msg, {
-          content = strip_citations(msg.content)
+          content = strip_citations(msg.content),
         })
       else
         return msg


### PR DESCRIPTION
closes #75 

I think this gets me what I wanted. Which is to say, I can now pass a system value in the header config all the way through (at least as long as I don't also start the first line with `>`, as this will overwrite the value).

What do you think?